### PR TITLE
Fix RightSidebar props typing

### DIFF
--- a/app/(root)/page.tsx
+++ b/app/(root)/page.tsx
@@ -26,10 +26,49 @@ const Home = async () => {
         RECENT TRANSACTIONS
       </div>
 
-      <RightSidebar  
-      user={loggedIn}
-      transactions={[]}
-      banks={[{currentBalance: 123.50}, {currentBalance: 500}]}
+      <RightSidebar
+        user={loggedIn}
+        transactions={[]}
+        banks={[
+          {
+            $id: "1",
+            accountId: "1",
+            bankId: "1",
+            accessToken: "",
+            fundingSourceUrl: "",
+            userId: "1",
+            sharableId: "1",
+            id: "1",
+            availableBalance: 0,
+            currentBalance: 123.5,
+            officialName: "",
+            mask: "",
+            institutionId: "",
+            name: "Bank 1",
+            type: "",
+            subtype: "",
+            appwriteItemId: "",
+          },
+          {
+            $id: "2",
+            accountId: "2",
+            bankId: "2",
+            accessToken: "",
+            fundingSourceUrl: "",
+            userId: "1",
+            sharableId: "2",
+            id: "2",
+            availableBalance: 0,
+            currentBalance: 500,
+            officialName: "",
+            mask: "",
+            institutionId: "",
+            name: "Bank 2",
+            type: "",
+            subtype: "",
+            appwriteItemId: "",
+          },
+        ]}
       />
     </section>
   );

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -217,7 +217,7 @@ declare interface FooterProps {
 declare interface RightSidebarProps {
   user: User;
   transactions: Transaction[];
-  banks: Bank[] & Account[];
+  banks: (Bank & Account)[];
 }
 
 declare interface SiderbarProps {


### PR DESCRIPTION
## Summary
- update RightSidebar props so each bank combines Bank and Account types
- pass full Bank & Account objects to RightSidebar on home page

## Testing
- `npm install`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6857c7114ce483319cdb87425ce2e5d2